### PR TITLE
Remove Null pointer and deprecated pointer method

### DIFF
--- a/UDPBroadcast/UDPBroadcastConnection.swift
+++ b/UDPBroadcast/UDPBroadcastConnection.swift
@@ -231,7 +231,7 @@ open class UDPBroadcastConnection {
 
 			debugPrint("UDP connection received \(bytesRead) bytes from \(endpoint.host):\(endpoint.port)")
 
-			let responseBytes = Data(response[0..<bytesRead])
+			let responseBytes = Data(bytes: &response, count: bytesRead)
 
 			// Handle response
 			self.handler?(endpoint.host, endpoint.port, responseBytes)


### PR DESCRIPTION
Removed Null pointer made required changes to codebase. This first portion could also just be simplified to 
```
let bitCount = 4096
let response = malloc(4096)
defer { response?.deallocate() }
			
let UDPSocket = Int32(source.handle)
            
let bytesRead = withUnsafeMutablePointer(to: &socketAddress) {
				recvfrom(UDPSocket, response, bitCount, 0, UnsafeMutableRawPointer($0).bindMemory(to: sockaddr.self, capacity: 1), &socketAddressLength)
            }
```

Line 166 must be changed to : 
```
var responseBytes = Data()
				
				if let response = response {
					responseBytes = Data(bytes: response, count: bytesRead)
				}
```

We actually took this approach in our project and it worked fine on iOS14. 