### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "UDPBroadcast",
+    platforms: [
+        .iOS(.v11),
+        .macOS(.v10_13),
+        .tvOS(.v12),
+        .watchOS(.v5)
+    ],
+    products: [
+        .library(
+            name: "UDPBroadcast",
+            targets: ["UDPBroadcast"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "UDPBroadcast",
+            dependencies: [],
+            path: "UDPBroadcast"
+        ),
+    ]
+)


### PR DESCRIPTION
Add a `Package.swift` to make the project useable through SPM. I used the same minimum requirements as for the frameworks expect for iOS which requires a minimum of 11 to be used.